### PR TITLE
Fix the case where the search query is empty

### DIFF
--- a/src/Controller/SearchController.php
+++ b/src/Controller/SearchController.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Setono\SyliusElasticsearchPlugin\Controller;
 
+use Elastica\Exception\ResponseException;
 use Elastica\Query;
 use Elastica\Query\Nested;
 use Elastica\Query\QueryString;
@@ -257,7 +258,7 @@ class SearchController extends Controller
     /**
      * Perform a product search using the index defined for the active locale.
      */
-    private function search(Request $request, string $queryString = ''): Pagerfanta
+    private function search(Request $request, string $queryString = ''): ?Pagerfanta
     {
         /** @var ArrayGridProvider $gridProvider */
         $gridProvider = $this->get('sylius.grid.provider');
@@ -281,6 +282,14 @@ class SearchController extends Controller
         $paginator = $this->productFinder->findPaginated($queryObject);
         $paginator->setMaxPerPage($request->get('limit', $this->pagination));
         $paginator->setCurrentPage($request->get('page', 1));
+
+        try {
+            if (null === $paginator->getNbResults()) {
+                return null;
+            }
+        } catch (ResponseException $exception) {
+            return null;
+        }
 
         return $paginator;
     }

--- a/src/Resources/views/index.html.twig
+++ b/src/Resources/views/index.html.twig
@@ -3,7 +3,7 @@
 
 {% block content %}
 
-    {% if results.nbResults > 0 %}
+    {% if results is not null and results.nbResults > 0 %}
 
         {% if filters is defined %}
             <section class="taxon-filters">

--- a/src/Resources/views/results.html.twig
+++ b/src/Resources/views/results.html.twig
@@ -23,7 +23,7 @@
     </div>
 </section>
 
-{% if results.nbResults > results.maxPerPage %}
+{% if results is not null and results.nbResults > results.maxPerPage %}
     <div class="container">
         {{ pagination.simple(results, {
             'prev_message': 'app.ui.pagination.previous'|trans,


### PR DESCRIPTION
If we submit an empty search, it results in this error  : 
![image](https://user-images.githubusercontent.com/9363039/103781664-eed00b80-5036-11eb-9e61-2cc1ba65cd6b.png)

So we should allow to return null, and the first call to `getNbResults` will throw an exception from Elasticsearch lib.